### PR TITLE
Fix stale state in phasesteelman

### DIFF
--- a/src/components/phases/PhaseSteelman.tsx
+++ b/src/components/phases/PhaseSteelman.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import DraftTextarea from '../ui/DraftTextarea';
 import { useAppContext } from '../../hooks/useAppContext';
 import { Problem } from '../../types';
@@ -24,6 +24,10 @@ const PhaseSteelman: React.FC<PhaseSteelmanProps> = ({ problem, onSave, onSubmit
 
     // This state now holds the real-time value of the textarea.
     const [draftText, setDraftText] = useState(problem[`${myRole}_steelman`] || '');
+
+    useEffect(() => {
+        setDraftText(problem[`${myRole}_steelman`] || '');
+    }, [problem, myRole]);
 
     // Determine the submission status for both the current user and their partner.
     const iHaveSubmitted = problem[`${myRole}_submitted_steelman`];

--- a/src/components/ui/DraftTextarea.tsx
+++ b/src/components/ui/DraftTextarea.tsx
@@ -1,24 +1,25 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 interface DraftTextareaProps {
     value: string;
-    onSave: (value: string) => void;
-    onSubmit: (value: string) => void;
+    onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+    onSave: () => void; // The parent now handles what to save
+    onSubmit: () => void; // The parent now handles what to submit
     placeholder?: string;
     disabled?: boolean;
     submitText?: string;
 }
 
 /**
- * A textarea component that saves drafts on blur and has an explicit submit button.
+ * A controlled textarea component that saves drafts on blur and has an explicit submit button.
+ * The parent component is responsible for managing the state of the text.
  */
 const DraftTextarea = React.forwardRef<HTMLTextAreaElement, DraftTextareaProps>(
-    ({ value, onSave, onSubmit, placeholder, disabled, submitText = "Submit & Lock" }, ref) => {
-        const [text, setText] = useState(value);
+    ({ value, onChange, onSave, onSubmit, placeholder, disabled, submitText = "Submit & Lock" }, ref) => {
 
         const handleBlur = () => {
-            if (!disabled && text !== value) {
-                onSave(text);
+            if (!disabled) {
+                onSave();
             }
         };
 
@@ -29,13 +30,13 @@ const DraftTextarea = React.forwardRef<HTMLTextAreaElement, DraftTextareaProps>(
                     className="w-full p-3 border-2 border-gray-700 rounded-lg bg-gray-800 text-gray-200 focus:ring-2 focus:ring-lime-400 focus:border-lime-400 transition disabled:bg-gray-700/50"
                     rows="8"
                     placeholder={placeholder}
-                    value={text}
-                    onChange={(e) => setText(e.target.value)}
+                    value={value} // Directly use the value from props
+                    onChange={onChange} // Pass the event up to the parent
                     onBlur={handleBlur}
                     disabled={disabled}
                 />
                 {!disabled && (
-                    <button onClick={() => onSubmit(text)} className="mt-4 bg-lime-500 hover:bg-lime-600 text-gray-900 font-bold py-2 px-4 rounded-lg transition">
+                    <button onClick={onSubmit} className="mt-4 bg-lime-500 hover:bg-lime-600 text-gray-900 font-bold py-2 px-4 rounded-lg transition">
                         {submitText}
                     </button>
                 )}

--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -14,7 +14,7 @@ const callGemini = async (prompt: string): Promise<string | null> => {
     // Halt execution if the API key is missing to prevent failed API calls.
     if (!apiKey) {
         console.error("Gemini API key is missing. Please set VITE_GEMINI_API_KEY in your .env file.");
-        throw new Error("Missing Gemini API key.");
+        return null;
     }
 
     const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=${apiKey}`;


### PR DESCRIPTION
This pull request refactors the `PhaseSteelman` and `DraftTextarea` components to make text input fully controlled by the parent component, improving state consistency and reducing redundant logic. It also adjusts the Gemini API error handling to return `null` instead of throwing when the API key is missing.

**Refactor to controlled components and state handling:**

* The `PhaseSteelman` component now manages the steelman draft text state locally and passes it down to `DraftTextarea`, ensuring real-time updates and consistent state between parent and child. The save logic is updated to only trigger when the text actually changes.
* The `DraftTextarea` component is refactored to be a fully controlled component, removing its internal state and relying on props for value and change handling. The parent now handles all text state and save/submit logic. [[1]](diffhunk://#diff-d2ef3be944c19eeaf24ec3ec45f6ffa638f608065fe0e3f170757961fc37b055L1-R22) [[2]](diffhunk://#diff-d2ef3be944c19eeaf24ec3ec45f6ffa638f608065fe0e3f170757961fc37b055L32-R39)

**API error handling improvement:**

* The Gemini API service (`callGemini`) now returns `null` instead of throwing an error when the API key is missing, allowing for more graceful error handling upstream.

**Type safety improvement:**

* The `onSave` prop type in `PhaseSteelmanProps` is updated to require a string value for each field, improving type safety.

## Summary by Sourcery

Refactor text input components to use controlled state in PhaseSteelman and DraftTextarea, fix stale draft state and redundant saves, improve Gemini API error handling, and tighten prop typing

Bug Fixes:
- Fix stale draftText state in PhaseSteelman to prevent redundant saves
- Change callGemini to return null instead of throwing when the API key is missing

Enhancements:
- Refactor PhaseSteelman to manage draftText locally, sync with props, and only trigger onSave when the text changes
- Convert DraftTextarea into a fully controlled component with value, onChange, onSave, and onSubmit handled by the parent
- Update BS Meter button to use real-time draftText and disable based on trimmed input
- Strengthen type safety by updating the onSave prop to require string values